### PR TITLE
Update v2.0.0.alpha-1.MD Release notes to remove the "2.0.0" from the release notes.

### DIFF
--- a/RELEASENOTES/v2.0.0.alpha-1.MD
+++ b/RELEASENOTES/v2.0.0.alpha-1.MD
@@ -1,12 +1,11 @@
-# Notary V2 Release Note
-# Version 2.0.0.alpha.1
+# Notary V2 Alpha 1 Release Note
 
 ## Overview
 NotaryV2 working group is pleased to annouce the first release v2.0.0.alpha.1. The release includes contribution from three different repoistories, all of which together constitute this  release
 
-- [Notary V2 standard](https://github.com/notaryproject/notaryproject) ***[(notaryproject-v1.0.0-draft.1)](https://github.com/notaryproject/notaryproject/issues/108)***
-- [Notation Library](https://github.com/notaryproject/notation-go-lib) ***[(notation-go-lib-v0.7.0-alpha.1)](https://github.com/notaryproject/notation-go-lib/issues/19)***
-- [Notation CLI](https://github.com/notaryproject/notation)   ***([notation-v0.7.0-alpha.1](https://github.com/notaryproject/notation/issues/104))***
+- [Notary V2 standard](https://github.com/notaryproject/notaryproject) ***[(notaryproject-v1.0.0-draft.1)](https://github.com/notaryproject/notaryproject/releases/tag/v1.0.0-draft.1)***
+- [Notation Library](https://github.com/notaryproject/notation-go-lib) ***[(notation-go-lib-v0.7.0-alpha.1)](https://github.com/notaryproject/notation-go-lib/releases/tag/v0.7.0-alpha.1)***
+- [Notation CLI](https://github.com/notaryproject/notation)   ***([notation-v0.7.0-alpha.1](https://github.com/notaryproject/notation/releases/tag/v0.7.0-alpha.1)***
 
 ## Goal of the release
 - Introduce the NotaryV2 standards which are currently work in progress
@@ -32,7 +31,7 @@ Written in the GO language the Library is currently focussed on enabling the Not
 Not Applicable. This is the first release of the NotaryV2
 
 ## List of known/open issues
-*This is not an exhaustive release. Users should refer to the Notary V2 roadmap at https://github.com/notaryproject/roadmap#readme for seeing the content for the subsequent releases*
+*This is not an exhaustive release. Users should refer to the Notary V2 roadmap at https://github.com/notaryproject/roadmap#readme for seeing the plan for subsequent releases*
 
 1. Does not support working with an external registry located on a different host. Use a localhost registry for this release.
 2. The passwords are stored in clear text.


### PR DESCRIPTION
@SteveLasker  - To avoid confusion I am removing the 2.0.0 prefix from Alpha-1 for the overall/aggregate release notes.  While  I was at it I also updated the links to the individual (auto generated) release notes for each of the repos.