### PR TITLE
Add Pritesh Bandi as roadmap maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @priteshbandi

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Pritesh Bandi <priteshbandi@gmail.com> (@priteshbandi)


### PR DESCRIPTION
Add Pritesh Bandi as a seed maintainer of roadmap based on their activity and as per - https://github.com/notaryproject/roadmap/issues/78

Signed-off-by: vaninrao10 <111005862+vaninrao10@users.noreply.github.com>