### PR TITLE
Added CODEOWNERS and MAINTAINERS files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,13 +1,3 @@
-# Org-Level Owners (in alphabetical order)
-* @justincormack 
-* @niazfk
-* @stevelasker
-
 # Repo-Level Owners (in alphabetical order)
 # Note: This is only for the notaryproject/roadmap repo
-* @FeynmanZhou
-* @iamsamirzon
-* @priteshbandi
-* @toddysm
-* @vaninrao10
-* @yizha1
+* @FeynmanZhou @justincormack @iamsamirzon @niazfk @priteshbandi @stevelasker @toddysm @vaninrao10 @yizha1

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,7 @@
 * @stevelasker
 
 # Repo-Level Owners (in alphabetical order)
-# Note: This is only for the notaryproject/notation repo
+# Note: This is only for the notaryproject/roadmap repo
 * @FeynmanZhou
 * @iamsamirzon
 * @priteshbandi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# Org-Level Owners (in alphabetical order)
+* @justincormack 
+* @niazfk
+* @stevelasker
+
+# Repo-Level Owners (in alphabetical order)
+# Note: This is only for the notaryproject/notation repo
+* @FeynmanZhou
+* @iamsamirzon
+* @priteshbandi
+* @toddysm
+* @vaninrao10
+* @yizha1

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,14 @@
+# Org-Level Maintainers (in alphabetical order)
+# Pattern: [First Name] [Last Name] <[Email Address]> ([GitHub Handle])
+Justin Cormack <justin.cormack@docker.com> (@justincormack)
+Niaz Khan <niazfk@amazon.com> (@niazfk)
+Steve Lasker <StevenLasker@hotmail.com> (@stevelasker)
+
+# Repo-Level Maintainers (in alphabetical order)
+# Note: This is for the notaryproject/notation repo
+Feynman Zhou <feynmanzhou@microsoft.com> (@FeynmanZhou)
+Pritesh Bandi <priteshbandi@gmail.com> (@priteshbandi)
+Samir Kakkar <iamsamir@amazon.com> (@iamsamirzon)
+Toddy Mladenov <toddysm@gmail.com> (@toddysm)
+Vani Rao <vaninrao@amazon.com> (@vaninrao10)
+Yi Zha <yizha1@microsoft.com> @yizha1

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -5,7 +5,7 @@ Niaz Khan <niazfk@amazon.com> (@niazfk)
 Steve Lasker <StevenLasker@hotmail.com> (@stevelasker)
 
 # Repo-Level Maintainers (in alphabetical order)
-# Note: This is for the notaryproject/notation repo
+# Note: This is for the notaryproject/roadmap repo
 Feynman Zhou <feynmanzhou@microsoft.com> (@FeynmanZhou)
 Pritesh Bandi <priteshbandi@gmail.com> (@priteshbandi)
 Samir Kakkar <iamsamir@amazon.com> (@iamsamirzon)


### PR DESCRIPTION
Signed-off-by: Toddy Mladenov <toddysm@gmail.com>

This PR combines all the changes from the following PRs for updating the maintainers for *notaryproject/roadmap* sub-project:
[Add Feynman Zhou](https://github.com/notaryproject/notaryproject.dev/pull/82) #82    
[Add Pritesh Bandi](https://github.com/notaryproject/notaryproject.dev/pull/79) #79    
[Add Samir Kakkar](https://github.com/notaryproject/notaryproject.dev/pull/80) #80    
[Add Toddy Mladenov](https://github.com/notaryproject/notaryproject.dev/pull/83) #83    
[Add Vani Rao](https://github.com/notaryproject/notaryproject.dev/pull/81) #81    
[Add Yi Zha](https://github.com/notaryproject/notaryproject.dev/pull/84) #84   

The proposal is to abandon the above PRs and merge only this one.